### PR TITLE
Change in calculating derv2.

### DIFF
--- a/OSPC/Helper.cs
+++ b/OSPC/Helper.cs
@@ -115,7 +115,9 @@ namespace OSPC
 
         public static double[] CalcDerv2(this double[] lst)
         {
-            var derv_2 = new double[lst.Length - 2];
+            var derv_2 = new double[0];
+            if (lst.Length < 2) return derv_2;
+            derv_2 = new double[lst.Length - 2];
             for (int i = 0; i < lst.Length - 2; i++)
             {
                 derv_2[i] = SlidingAvg(lst, i) - 2 * SlidingAvg(lst, i + 1) + SlidingAvg(lst, i + 2);

--- a/OSPC/OSPCResult.cs
+++ b/OSPC/OSPCResult.cs
@@ -47,21 +47,24 @@ namespace OSPC
             if (lst.Length > 0)
             {
                 result.AVG_Similarity = lst.Average();
-                result.POI_Similarity = lst[lst.CalcDerv2().MaxIndex()];
+                double[] derv2 = lst.CalcDerv2();
+                if (derv2.Length > 0) result.POI_Similarity = lst[derv2.MaxIndex()];
             }
 
             lst = result.Results.Select(i => (double)i.TokenCount).OrderBy(i => i).ToArray();
             if (lst.Length > 0)
             {
                 result.AVG_TokenCount = lst.Average();
-                result.POI_TokenCount = lst[lst.CalcDerv2().MaxIndex()];
+                double[] derv2 = lst.CalcDerv2();
+                if (derv2.Length > 0) result.POI_TokenCount = lst[derv2.MaxIndex()];
             }
 
             lst = result.Results.Select(i => (double)i.TokenCount / (double)i.MatchCount).OrderBy(i => i).ToArray();
             if (lst.Length > 0)
             {
                 result.AVG_TokenPerMatch = lst.Average();
-                result.POI_TokenPerMatch = lst[lst.CalcDerv2().MaxIndex()];
+                double[] derv2 = lst.CalcDerv2();
+                if (derv2.Length > 0) result.POI_TokenPerMatch = lst[derv2.MaxIndex()];
 
             }
             return result;


### PR DESCRIPTION
Hello Arthur,
I've started using this great project of yours earlier today and I've noticed it throws System.IndexOutOfRangeException in `OSPCResult.Create` method when there are only two files to be compared.
Exception ocurres on line
`result.POI_Similarity = lst[lst.CalcDerv2().MaxIndex()];`
because `CalcDerv2()` returns an empty array and `MaxIndex()` then returns the default -1.
Also, `CalcDerv2()` would throw System.OverflowException when passed an array containing less than two elements.
I thought that a straightforward workaround to this would be simply not to try to calculate POI_Similarity when unable to calulate the derivation, so I've made some changes to avoid having these error messages show up. It would be great if If you could review them.
Best regards,
Antonia
